### PR TITLE
Catch errors properly in IE

### DIFF
--- a/examples/debug.html
+++ b/examples/debug.html
@@ -83,7 +83,8 @@
                 wrap_line_length: 160,
                 wrap_attributes: 'force-expand-multiline'
               })
-            } catch {
+            } catch (err) {
+              console.error(err)
               return html
             }
           }


### PR DESCRIPTION
This try catch was failing in IE because of the lack of argument. This
also logs the error for good measure.