### PR TITLE
Configure Travis to publish to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,36 @@ node_js:
 script:
   - npm run test
   - npm run build
-# This deploy requires a Github personal access token, so if this breaks it
-# could be that the developer has left GDS.
+after_success:
+  - export LOCAL_VERSION=$(node -p "require('./package.json').version")
+  - export REMOTE_VERSION=$(npm view paste-html-to-govspeak version)
+  - export GIT_TAG=$(git tag | grep $LOCAL_VERSION)
+  - export GIT_REMOTE=https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  keep_history: true
-  local_dir: examples
-  on:
-    branch: master
+  # This deploy requires a Github personal access token, so if this breaks it
+  # could be that the developer has left GDS.
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    keep_history: true
+    local_dir: examples
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: git tag $LOCAL_VERSION && git push $GIT_REMOTE --tags
+    on:
+      branch: master
+      condition: -z "$GIT_TAG"
+  - provider: npm
+    skip_cleanup: true
+    email: govuk-dev@digital.cabinet-office.gov.uk
+    api_key: $NPM_TOKEN
+    on:
+      branch: master
+      condition: $LOCAL_VERSION != $REMOTE_VERSION
+cache:
+  directories:
+   - node_modules
+notifications:
+  email: false


### PR DESCRIPTION
Deploy to npm from master only on tagged commits using secure api key.

[Trello card](https://trello.com/c/e1AYHybj)