### PR TITLE
 Fix the mysterious case of spaces being removed

### DIFF
--- a/src/to-govspeak.js
+++ b/src/to-govspeak.js
@@ -2,7 +2,19 @@ import TurndownService from 'turndown'
 
 const service = new TurndownService({
   bulletListMarker: '-',
-  listIndent: '   ' // 3 spaces
+  listIndent: '   ', // 3 spaces
+  blankReplacement: (content, node) => {
+    if (node.isBlock) {
+      return '\n\n'
+    }
+
+    // This fixes an issue with turndown where an element with a space
+    // inside can be removed causing a jarring HTML coversion.
+    const hasWhitespace = /\s/.test(node.textContent)
+    const hasFlanking = node.flankingWhitespace.trailing || node.flankingWhitespace.leading
+
+    return hasWhitespace && !hasFlanking ? ' ' : ''
+  }
 })
 
 // As a user may have pasted markdown we rather crudley

--- a/test/to-govspeak.test.js
+++ b/test/to-govspeak.test.js
@@ -5,7 +5,6 @@ import toGovspeak from '../src/to-govspeak'
 it('converts HTML to govspeak', () => {
   expect(toGovspeak('<p>Hello</p>')).toEqual('Hello')
 })
-
 it("doesn't escape markdown", () => {
   const html = '<p>[Markdown](link)</p>'
   expect(toGovspeak(html)).toEqual('[Markdown](link)')
@@ -183,4 +182,19 @@ it('fixes an invalid nested ordered list that Google Docs produces', () => {
     '   3. Child 3\n' +
     '2. Parent sibling'
   )
+})
+
+it('Fixes cases where a <span>&nbsp;</span> has the space stripped', () => {
+  const html = `Some text<span>&nbsp;</span>and some more text`
+
+  expect(toGovspeak(html)).toEqual('Some text and some more text')
+})
+
+// This test is here to document an undesirable case that took a lot of
+// investigation. This should be resolved when/if https://github.com/domchristie/turndown/pull/281
+// is released.
+it('Maintains behaviour where a <span> </span> produces a double space', () => {
+  const html = `Some text<span> </span>and some more text`
+
+  expect(toGovspeak(html)).toEqual('Some text  and some more text')
 })


### PR DESCRIPTION
Trello: https://trello.com/c/P5KBetGh/754-resolve-issues-identified-from-copy-and-paste-testing

This was a rather hard problem to solve, so brace yourself as this
message might be complex.

We were having cases of HTML pasted from browsers adding span elements in
for spaces. So we could end up with HTML like:
`Some text<span> </span><a href="">Link</a>` where, depending on the
environment, the contents of the span could be `<span>&nbsp;</span>` or
`<span> </span>`. In browsers it was the former.

This causes some poor behaviour in turndown where the presence of a
nbsp; character (which has an ASCII code of 160) causes the whole space
to be stripped out, resulting in `Some text[Link]()` as output. On the
other hand the presence of a normal space (ASCII code 32) causes a
different problem of two spaces, resulting in output such as `Some text
[Link]()`.

This problem is due to Turndowns whitespace rules where they only match
a normal space character: https://github.com/domchristie/turndown/blob/80297cebeae4b35c8d299b1741b383c74eddc7c1/src/node.js#L25-L33