### PR TITLE
Auto-tag and publish to NPM via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,36 @@ node_js:
 script:
   - npm run test
   - npm run build
-# This deploy requires a Github personal access token, so if this breaks it
-# could be that the developer has left GDS.
+after_success:
+  - export LOCAL_VERSION=$(node -p "require('./package.json').version")
+  - export REMOTE_VERSION=$(npm view paste-html-to-govspeak version)
+  - export GIT_TAG=$(git tag | grep $LOCAL_VERSION)
+  - export GIT_REMOTE=https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  keep_history: true
-  local_dir: examples
-  on:
-    branch: master
+  # This deploy requires a Github personal access token, so if this breaks it
+  # could be that the developer has left GDS.
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    keep_history: true
+    local_dir: examples
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: git tag $LOCAL_VERSION && git push $GIT_REMOTE --tags
+    on:
+      branch: master
+      condition: -z "$GIT_TAG"
+  - provider: npm
+    skip_cleanup: true
+    email: govuk-dev@digital.cabinet-office.gov.uk
+    api_key: $NPM_TOKEN
+    on:
+      branch: master
+      condition: $LOCAL_VERSION != $REMOTE_VERSION
+cache:
+  directories:
+   - node_modules
+notifications:
+  email: false


### PR DESCRIPTION
https://trello.com/c/e1AYHybj/672-put-together-the-copy-and-paste-work-as-a-package-that-can-be-included

This configures Travis to automatically push a new tagged version when
the package version in package.json changes, as well as push the new
version to NPM if it isn't already there. We use different checks for
each function to ensure they can run independently if one of them fails.