### PR TITLE
Fix tag deploy test (invert flag)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ deploy:
     script: git tag $LOCAL_VERSION && git push $GIT_REMOTE --tags
     on:
       branch: master
-      condition: -z "$GIT_TAG"
+      condition: -n "$GIT_TAG"
   - provider: npm
     skip_cleanup: true
     email: govuk-dev@digital.cabinet-office.gov.uk


### PR DESCRIPTION
https://trello.com/c/e1AYHybj/672-put-together-the-copy-and-paste-work-as-a-package-that-can-be-included

Previously we were trying to push a tag if it already existed, instead
of if it did not exist.