### PR TITLE
Improve element removal and remove preceding whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Unreleased
 
 - Fix dist file containing ES2015 and regex breaking in IE11 (PR #39)
+- Remove more undesirable elements and trim output whitespace (PR #38)
 
 ## 0.1.1
 

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -17,6 +17,22 @@ const service = new TurndownService({
   }
 })
 
+// define all the elements we want stripped from output
+const elementsToRemove = [
+  'title',
+  'script',
+  'noscript',
+  'style',
+  'video',
+  'audio',
+  'object',
+  'iframe'
+]
+
+for (const element of elementsToRemove) {
+  service.remove(element)
+}
+
 // As a user may have pasted markdown we rather crudley
 // stop all escaping
 service.escape = (string) => string
@@ -76,6 +92,14 @@ service.addRule('heading', {
   }
 })
 
+// remove images
+// this needs to be set as a rule rather than remove as it's part of turndown
+// commonmark rules that needs overriding
+service.addRule('img', {
+  filter: ['img'],
+  replacement: () => ''
+})
+
 // remove bold
 service.addRule('bold', {
   filter: ['b', 'strong'],
@@ -88,22 +112,10 @@ service.addRule('italic', {
   replacement: (content) => content
 })
 
-// remove images
-service.addRule('img', {
-  filter: ['img'],
-  replacement: () => ''
-})
-
 service.addRule('removeEmptyParagraphs', {
   filter: (node) => {
     return node.nodeName.toLowerCase() === 'p' && node.textContent.trim() === ''
   },
-  replacement: () => ''
-})
-
-// remove style elements
-service.addRule('style', {
-  filter: ['style'],
   replacement: () => ''
 })
 

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -209,8 +209,10 @@ function extractHeadingsFromLists (govspeak) {
 }
 
 function postProcess (govspeak) {
-  let govspeakWithExtractedHeadings = extractHeadingsFromLists(govspeak)
-  return removeBrParagraphs(govspeakWithExtractedHeadings)
+  const govspeakWithExtractedHeadings = extractHeadingsFromLists(govspeak)
+  const brsRemoved = removeBrParagraphs(govspeakWithExtractedHeadings)
+  const whitespaceStripped = brsRemoved.trim()
+  return whitespaceStripped
 }
 
 export default function htmlToGovspeak (html) {

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -5,6 +5,7 @@ import htmlToGovspeak from '../src/html-to-govspeak'
 it('converts HTML to govspeak', () => {
   expect(htmlToGovspeak('<p>Hello</p>')).toEqual('Hello')
 })
+
 it("doesn't escape markdown", () => {
   const html = '<p>[Markdown](link)</p>'
   expect(htmlToGovspeak(html)).toEqual('[Markdown](link)')
@@ -55,6 +56,65 @@ it('removes image elements', () => {
   expect(htmlToGovspeak('<img src="image.jpg" alt="" />')).toEqual('')
 })
 
+it('removes title elements', () => {
+  expect(htmlToGovspeak(`<title>Title</title>`)).toEqual('')
+})
+
+it('removes script elements', () => {
+  expect(htmlToGovspeak(`<script>alert('hi')</script>`)).toEqual('')
+})
+
+it('removes noscript elements', () => {
+  expect(htmlToGovspeak(`<noscript>Enable JS</noscript>`)).toEqual('')
+})
+
+it('removes style elements', () => {
+  expect(htmlToGovspeak(`<style>p {color:red;}</style>`)).toEqual('')
+})
+
+it('removes video elements', () => {
+  const html = `
+    <video width="320" height="240" controls>
+      <source src="movie.mp4" type="video/mp4">
+      <source src="movie.ogg" type="video/ogg">
+      Fallback text
+    </video>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('')
+})
+
+it('removes audio elements', () => {
+  const html = `
+    <audio controls src="/media/examples/t-rex-roar.mp3">
+      Fallback text
+    </audio>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('')
+})
+
+it('removes object elements', () => {
+  const html = `
+    <object type="application/pdf"
+      data="/media/examples/In-CC0.pdf"
+      width="250"
+      height="200">
+      Fallback text
+    </object>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('')
+})
+
+it('removes iframe elements', () => {
+  const html = `
+    <iframe src="./file">Fallback text</iframe>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('')
+})
+
 it('converts abbr elements to references', () => {
   const html = `
     <p>
@@ -96,10 +156,6 @@ it('removes rogue br elements', () => {
   expect(htmlToGovspeak(html)).toEqual(
     'Not empty\n\nNot empty either'
   )
-})
-
-it('removes style elements', () => {
-  expect(htmlToGovspeak(`<style>p {color:red;}</style>`)).toEqual('')
 })
 
 it('extracts headers from lists', () => {

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -254,3 +254,15 @@ it('Maintains behaviour where a <span> </span> produces a double space', () => {
 
   expect(htmlToGovspeak(html)).toEqual('Some text  and some more text')
 })
+
+// The presence of elements preceeding text that is rendered can cause
+// preceeding whitespace. Typically this is caused by elements in the <head>
+// that are to be stripped out.
+it('strips whitespace caused by surrounding, non-visual elements', () => {
+  const html = `
+    <meta charset="utf-8">
+    <title>Title</title>
+    <p>Some text</p>
+  `
+  expect(htmlToGovspeak(html)).toEqual('Some text')
+})


### PR DESCRIPTION
Trello: https://trello.com/c/Fhqmp62n/771-document-outcome-of-testing-paste-html-to-govspeak

This removes some elements that weren't being removed by default and iterates the syntax for removing elements.

This also fixes a common situation where pasting leads to a bunch of preceding whitespace. I identified that this was caused by elements in `<head>` that are removed interacting with the first visible element. This can be resolved rather simply by trimming the govspeak being output.