### PR TITLE
Convert headers to h2 or h3 rather than strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- Convert h1 headers to h2, convert h4 and h5 headers to h3 (PR #41)
 - Fix dist file containing ES2015 and regex breaking in IE11 (PR #39)
 
 ## 0.1.1

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -59,14 +59,17 @@ service.addRule('abbr', {
   }
 })
 
-// Create a govspeak heading rule
+// GOV.UK content authors are encouraged to only use h2 and h3 headers, this
+// converts other headers to be one of these (except h6 which is converted
+// to a paragraph
 service.addRule('heading', {
   filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
   replacement: (content, node) => {
     let prefix
-    if (node.nodeName.charAt(1) === '2') {
+    let number = node.nodeName.charAt(1)
+    if (number === '1' || number === '2') {
       prefix = '## '
-    } else if (node.nodeName.charAt(1) === '3') {
+    } else if (number === '3' || number === '4' || number === '5') {
       prefix = '### '
     } else {
       prefix = ''

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -34,10 +34,16 @@ it('maintains H2 and H3 headers', () => {
   expect(htmlToGovspeak('<h3>Hello</h3>')).toEqual('### Hello')
 })
 
-it('strips other headers', () => {
-  expect(htmlToGovspeak('<h1>Hello</h1>')).toEqual('Hello')
-  expect(htmlToGovspeak('<h4>Hello</h4>')).toEqual('Hello')
-  expect(htmlToGovspeak('<h5>Hello</h5>')).toEqual('Hello')
+it('converts h1 headers to h2', () => {
+  expect(htmlToGovspeak('<h1>Hello</h1>')).toEqual('## Hello')
+})
+
+it('converts h4 and h5 headers to h3', () => {
+  expect(htmlToGovspeak('<h4>Hello</h4>')).toEqual('### Hello')
+  expect(htmlToGovspeak('<h5>Hello</h5>')).toEqual('### Hello')
+})
+
+it('strips h6 headers', () => {
   expect(htmlToGovspeak('<h6>Hello</h6>')).toEqual('Hello')
 })
 


### PR DESCRIPTION
Trello: https://trello.com/c/Fhqmp62n/771-document-outcome-of-testing-paste-html-to-govspeak

GOV.UK supports h2 and h3 headers (with h4 allowed but discouraged). h1
headers are reserved for the page title. Previously this was supported
by stripping h1, h4, h5, and h6 headers.

A product decision has been made that instead of stripping h1, h4 and h5
elements these are converted to h2 or h3s, so that they are preserved of
headers but lose some of their hierarchical meaning.