### PR TITLE
Widen support of Word HTML lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Widen word list support (PR #46)
+
 ## 0.2.0
 
 - Convert Microsoft Word lists to markdown lists (PR #42)

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -321,3 +321,26 @@ it('Converts a MS Word nested list to a markdown list', () => {
     '   1. Parent 2 Child 1'
   )
 })
+
+it('Converts a MS Word list that uses msoNormal classes', () => {
+  // simplified version of the HTML word creates
+  const html = `
+    <p class="MsoNormal" style="mso-list:l0 level1 1fo1">
+      <span>
+        <span style="mso-list:Ignore">·</span>
+        <span>Item 1</span>
+      </span>
+    </p>
+    <p class="MsoNormal" style="mso-list:l0 level1 1fo1">
+      <span>
+        <span style="mso-list:Ignore">·</span>
+        <span>Item 2</span>
+      </span>
+    </p>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual(
+    '- Item 1\n' +
+    '- Item 2'
+  )
+})


### PR DESCRIPTION
Trello: https://trello.com/c/Fhqmp62n/771-document-outcome-of-testing-paste-html-to-govspeak

So shortly after releasing the Word list HTML conversion I found some
documents opened in word that didn't behave the same as the other ones I
tested (le sigh).

Looking at the HTML that was produced there showed a lack of list class
names and instead usage of the MsoNormal class (which Word normally uses
for paragraphs).

It wasn't too hard to change the code we have now to handle both of
these scenarios so I've updated it for this.