### PR TITLE
Strip links that seem to be pasted from address bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Strip links that match URL and are the only content of a paste document (PR #48)
+
 ## 0.2.1
 
 - Widen word list support (PR #46)

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -285,6 +285,23 @@ service.addRule('addWordListItem', {
   }
 })
 
+// Remove links that have same href as link text and are the only content
+// in a pasted document. This is because we assume here that they're trying
+// to paste just a plain text URL.
+service.addRule('removeAddressBarLinks', {
+  filter: (node, options) => {
+    if (node.nodeName.toLowerCase() !== 'a' || !node.getAttribute('href')) {
+      return
+    }
+
+    const href = node.getAttribute('href').trim()
+
+    return href === node.textContent.trim() &&
+      href === node.ownerDocument.body.textContent.trim()
+  },
+  replacement: (content) => content
+})
+
 function removeBrParagraphs (govspeak) {
   // This finds places where we have a br in a paragraph on it's own and
   // removes it.

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -344,3 +344,12 @@ it('Converts a MS Word list that uses msoNormal classes', () => {
     '- Item 2'
   )
 })
+
+it('Doesn\'t preserve markdown that is only a link with similar text to the link', () => {
+  // If you paste the URL from the address bar of chrome this is the HTML created
+  const html = `
+    <meta charset='utf-8'><a href="https://alphagov.github.io/paste-html-to-govspeak/">https://alphagov.github.io/paste-html-to-govspeak/</a>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('https://alphagov.github.io/paste-html-to-govspeak/')
+})


### PR DESCRIPTION
Trello: https://trello.com/c/7pL98HiY/780-investigate-chrome-address-bar-copy-and-paste-issue

Pasting from the address bar in Google Chrome produces a HTML output of
the link, for example going to
`https://alphagov.github.io/paste-html-to-govspeak/` and then selecting the
address bar and copying will produce HTML of:

    <meta charset='utf-8'><a href="https://alphagov.github.io/paste-html-to-govspeak/">https://alphagov.github.io/paste-html-to-govspeak/</a>

This causes a real problem in one of the use cases of this tool: when
users are embedding a link into their content and paste it from the
address bar.

The approach to solve this is to strip links in the following scenario:

- When link text matches link content
- When the link content is the same as the body of the HTML document