### PR TITLE
Check for clipboard access on the 'legacy' approach

### DIFF
--- a/src/legacy-html-from-paste.js
+++ b/src/legacy-html-from-paste.js
@@ -24,7 +24,15 @@ function getHtmlUsingHiddenElement (hiddenElement) {
   return hiddenElement.innerHTML
 }
 
+// Check for write access to clipboard, otherwise we're not allowed by the browser to paste in a contenteditable container
+function haveClipboardAccess () {
+  return window.clipboardData && window.clipboardData.setData('Text', '')
+}
+
 export default function legacyHtmlFromPaste () {
+  if (!haveClipboardAccess()) {
+    return false
+  }
   const hiddenElement = createHiddenElement()
   const html = getHtmlUsingHiddenElement(hiddenElement)
   removeElement(hiddenElement)

--- a/test/legacy-html-from-paste.test.js
+++ b/test/legacy-html-from-paste.test.js
@@ -2,8 +2,14 @@
 
 import legacyHtmlFromPaste from '../src/legacy-html-from-paste'
 
-it('returns the HTML entered by a paste exec command', () => {
+beforeEach(() => {
+  window.clipboardData = {}
+  window.clipboardData.setData = jest.fn()
+})
+
+it('returns the HTML entered by a paste exec command when clipboard access is enabled', () => {
   const html = '<p>Some text</p>'
+  window.clipboardData.setData.mockReturnValue(true)
 
   document.execCommand = (type) => {
     if (type === 'paste') {
@@ -13,5 +19,20 @@ it('returns the HTML entered by a paste exec command', () => {
   }
 
   expect(legacyHtmlFromPaste()).toEqual(html)
+  expect(document.body.lastChild).toBe(null)
+})
+
+it('returns the false when clipboard access is disabled', () => {
+  const html = '<p>Some text</p>'
+  window.clipboardData.setData.mockReturnValue(false)
+
+  document.execCommand = (type) => {
+    if (type === 'paste') {
+      // we expect a temporary element to exist at the point of pasting
+      document.body.lastChild.innerHTML = html
+    }
+  }
+
+  expect(legacyHtmlFromPaste()).toEqual(false)
   expect(document.body.lastChild).toBe(null)
 })


### PR DESCRIPTION
We check for write access to clipboard before trying to take the legacy approach, otherwise we run into a bug where we're not allowed by the browser to paste in a `contenteditable` container (which is the workaround used in this approach) when the user declines access to clipboard or the "Programmatic clipboard access" is disabled in Internet Options in IE.

This solution have been tested in the following scenarios:
- Paste into our input and the clipboard data is preserved
- Paste into our input and then on another web page and both times the clipboard data is preserved
- Paste into our input and then into another application (Notepad) and both times the clipboard data is preserved

[Trello card](https://trello.com/c/YUzyMrrn)