### PR TITLE
Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.2.3
+
+- Fix error when pasting content at the end of the textarea in IE11 by updating insert-text-at-cursor to 0.3.0 (PR #53)
+- Fix paste action when access to clipboard is disabled in IE11 (PR #52)
+
 ## 0.2.2
 
 - Strip links that match URL and are the only content of a paste document (PR #48)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Converts HTML formatted rich content to govspeak format (a markdown extension library for government editors) when pasted from clipboard into a form input or textarea.",
   "main": "dist/paste-html-to-markdown.js",
   "scripts": {


### PR DESCRIPTION
- Fix error when pasting content at the end of the textarea in IE11 by updating insert-text-at-cursor to 0.3.0 (PR #53)
- Fix paste action when access to clipboard is disabled in IE11 (PR #52)
