### PR TITLE
Set edge true to travis deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ deploy:
   # This deploy requires a Github personal access token, so if this breaks it
   # could be that the developer has left GDS.
   - provider: pages
+    edge: true
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
     keep_history: true
@@ -20,12 +21,14 @@ deploy:
     on:
       branch: master
   - provider: script
+    edge: true
     skip_cleanup: true
     script: git tag $LOCAL_VERSION && git push $GIT_REMOTE --tags
     on:
       branch: master
       condition: -z $GIT_TAG
   - provider: npm
+    edge: true
     skip_cleanup: true
     email: govuk-dev@digital.cabinet-office.gov.uk
     api_key: $NPM_TOKEN


### PR DESCRIPTION
Travis is currently raising errors stating that an API key is missing.
This is because of an issue at travis [1] which can be resolved with this
edge: true [2] argument to opt into new behaviour.

[1]: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/8
[2]: https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2