### PR TITLE
Switch from repo secret to organisation secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         if: ${{ steps.version.outputs.local != steps.version.outputs.remote }}
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.ALPHAGOV_NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
This swaps the use of a NPM_TOKEN secret local to this repo to an
organisation secret that is scoped to this repo.