### PR TITLE
Allow the GITHUB_TOKEN write permission on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write     
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
As of 1st February 2022, the org-wide setting for GitHub Actions have been changes so that an action runs by default with a "read" permission rather than the previous "read/write".

In order to have write permission we need to specify a permissions flag in the configuration.