### PR TITLE
Allow H4s to H6s with Paste to Govspeak converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.3.0
+
+- Maintain heading level from H2 to H6 (PR #235)
+
 ## 0.2.6
 
 - Reduce unnecessary files from node module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "paste-html-to-govspeak",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Converts HTML formatted rich content to govspeak format (a markdown extension library for government editors) when pasted from clipboard into a form input or textarea.",
   "main": "dist/paste-html-to-markdown.js",
   "scripts": {

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -81,17 +81,11 @@ service.addRule('abbr', {
 service.addRule('heading', {
   filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
   replacement: (content, node) => {
-    let prefix
-    const number = node.nodeName.charAt(1)
-    if (number === '1' || number === '2') {
-      prefix = '## '
-    } else if (number === '3' || number === '4' || number === '5') {
-      prefix = '### '
-    } else {
-      prefix = ''
-    }
+    let headingLevel = parseInt(node.nodeName.charAt(1))
+    headingLevel = headingLevel === 1 ? 2 : headingLevel
+    const prefix = Array(headingLevel + 1).join('#')
 
-    return `\n\n${prefix}${content}\n\n`
+    return `\n\n${prefix} ${content}\n\n`
   }
 })
 

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -37,22 +37,16 @@ it('converts lists to a dash bullet style', () => {
   expect(htmlToGovspeak(html)).toEqual('- Item 1\n- Item 2')
 })
 
-it('maintains H2 and H3 headers', () => {
-  expect(htmlToGovspeak('<h2>Hello</h2>')).toEqual('## Hello')
-  expect(htmlToGovspeak('<h3>Hello</h3>')).toEqual('### Hello')
-})
-
 it('converts h1 headers to h2', () => {
   expect(htmlToGovspeak('<h1>Hello</h1>')).toEqual('## Hello')
 })
 
-it('converts h4 and h5 headers to h3', () => {
-  expect(htmlToGovspeak('<h4>Hello</h4>')).toEqual('### Hello')
-  expect(htmlToGovspeak('<h5>Hello</h5>')).toEqual('### Hello')
-})
-
-it('strips h6 headers', () => {
-  expect(htmlToGovspeak('<h6>Hello</h6>')).toEqual('Hello')
+it('maintains headers from h2 to h6 headers', () => {
+  expect(htmlToGovspeak('<h2>Hello</h2>')).toEqual('## Hello')
+  expect(htmlToGovspeak('<h3>Hello</h3>')).toEqual('### Hello')
+  expect(htmlToGovspeak('<h4>Hello</h4>')).toEqual('#### Hello')
+  expect(htmlToGovspeak('<h5>Hello</h5>')).toEqual('##### Hello')
+  expect(htmlToGovspeak('<h6>Hello</h6>')).toEqual('###### Hello')
 })
 
 it('strips b and strong elements', () => {


### PR DESCRIPTION
## What
Currently the Paste to Govspeak converter (paste-html-to-govspeak) in the publishing applications automatically converts any H4s, H5s and H6s to a H3.

We want to remove this functionality and allow H4s, H5s and H6s without them being converted to H3s.

This change allows all headers from h2 to h6.

## Why
Although GOV.UK doesn't style H4s and below (in non-HTML attachments), it's important for users using assistive technology get the correct heading structure.

https://trello.com/c/aWGmHS2s/573-allow-h4s-to-h6s-with-paste-to-govspeak-converter