### PR TITLE
Ensure IE 11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "lint": "standard",
     "watch": "npm-watch"
   },
+  "babel": {
+    "presets": ["@babel/preset-env"]
+  },
+  "browserslist": "defaults, IE 11",
   "jest": {
     "testEnvironment": "jsdom"
   },


### PR DESCRIPTION
Babel has recently dropped IE11 support.

This change ensures that we target IE11 specifically as well as the defaults supported by Babel.

Needed for #235 