### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm run watch
 
 ## License
 
-Distributed under the MIT license. See LICENSE for details.
+[MIT License](LICENCE)
 
 [govspeak]: https://github.com/alphagov/govspeak
 [dist-file]: https://alphagov.github.io/paste-html-to-govspeak/dist/paste-html-to-markdown.js


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence