### PR TITLE
Version 0.5.0: fixes to email link markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.5.0
+
+- Make email links use the recommended markdown style
+
 ## 0.4.0
 
 - Add table plugin for handling tables

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ To continuously build files while developing run:
 npm run watch
 ```
 
+## Deployment
+
+The npmjs.com hosted module [paste-html-to-govspeak](https://www.npmjs.com/package/paste-html-to-govspeak) is automatically updated [when there is a merge to `main` that updates the `version` property in package.json](https://github.com/alphagov/paste-html-to-govspeak/blob/c280e7047ba612cbd5f479c37b8d41b18957207c/.github/workflows/ci.yml#L57-L61).
+
 ## License
 
 [MIT License](LICENCE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "paste-html-to-govspeak",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paste-html-to-govspeak",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Converts HTML formatted rich content to govspeak format (a markdown extension library for government editors) when pasted from clipboard into a form input or textarea.",
   "main": "dist/paste-html-to-markdown.js",
   "scripts": {

--- a/src/html-to-govspeak.js
+++ b/src/html-to-govspeak.js
@@ -38,7 +38,12 @@ service.addRule('link', {
     if (content.trim() === '') {
       return ''
     } else {
-      return `[${content}](${node.getAttribute('href')})`
+      const mailtoLink = node.getAttribute('href').match(/^mailto:(.+)$/)
+      if (mailtoLink) {
+        return `<${mailtoLink[1]}>`
+      } else {
+        return `[${content}](${node.getAttribute('href')})`
+      }
     }
   }
 })

--- a/test/html-to-govspeak.test.js
+++ b/test/html-to-govspeak.test.js
@@ -339,6 +339,14 @@ it('Doesn\'t preserve markdown that is only a link with similar text to the link
   expect(htmlToGovspeak(html)).toEqual('https://alphagov.github.io/paste-html-to-govspeak/')
 })
 
+it('Copies email links in the preferred markdown style', () => {
+  const html = `
+    <p class="p1">Contact <a href="mailto:hello@example.com"><span class="s1">hello@example.com</span></a>.</p>
+  `
+
+  expect(htmlToGovspeak(html)).toEqual('Contact <hello@example.com>.')
+})
+
 it('Converts Google Docs tables to markdown', () => {
   const html = openFixture('google-docs-2023-table.html')
 


### PR DESCRIPTION
Our guidance is for email links to be the email address wrapped in less than / greater than arrows:
https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#:~:text=admin/publications/123456.-,Email%20links,-Use%20%E2%80%98less%20than

Prior to this commit, paste-html-to-govspeak would output normal markdown links instead, i.e.
`[example@example.com](mailto:example@example.com)`

Trello: https://trello.com/c/w38PbWxD/