### PR TITLE
Add dependabot cooldown and open pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: monthly
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   - package-ecosystem: "github-actions"
     directory: /
@@ -14,3 +15,4 @@ updates:
       interval: monthly
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@ updates:
     dependency-type: production
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+
   - package-ecosystem: "github-actions"
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds a dependabot cooldown of 3 days and increases the upper limit on dependabot PRs to 25, as agreed in https://gov-uk.atlassian.net/browse/WHIT-3369