### PR TITLE
Fix invalid dependency-type key in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,8 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
-    dependency-type: production
+    allow:
+      - dependency-type: production
     schedule:
       interval: monthly
     cooldown:


### PR DESCRIPTION
The Dependabot Updates workflow has been failing schema validation:

> The property `#/updates/0/` contains additional properties ["dependency-type"] outside of the schema when none are allowed

## Cause

`dependency-type: production` was added as a top-level key on the npm `updates` entry in b4e74c4. `dependency-type` is only valid nested inside an `allow:` (or `ignore:`) rule, so the whole config failed validation and Dependabot bailed out before doing any work.

## Fix

Move it under an `allow:` rule:

```yaml
allow:
  - dependency-type: production
```

This restores the behaviour originally intended in b4e74c4 — only raise PRs for production dependencies (plus security updates), not devDependencies — using the valid schema form. It matches how `dependency-type` was nested under `allow:` previously, before that allow list was removed in ee17ef5.